### PR TITLE
First initial draft of records for the pg definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ target:
         - frdm-k64f
     mcu:
         - mcu/freescale/mk64fn1m0xxx12
-
 ```
 
 ### MCU
@@ -29,7 +28,7 @@ mcu:
         - lpc1768
     core:
         - cortex-m3
-tools:
+tool_specific:
     uvision:
         TargetOption:
             Device:
@@ -45,6 +44,8 @@ tools:
             SFDFile:
                 - SFD\NXP\LPC176x5x\LPC176x5x.SFR
 ```
+
+The data give in the mcu and target use lower cases, also files within this directory to keep consistency. The tool specific data follow the tools definitions.
 
 All this data must be manually written at the moment. We might add a parser for given project file, to generate valid record file for given tool.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# project_generator_definitions
-Definitions for project generator
+# Project generator definitions
+
+This repository defines definitions for targets and mcus. They are used to set proper data in the tools.
+
+## YAML records description
+
+### Target
+
+Target record defines the name and mcu it contains.
+
+```
+target:
+    name:
+        - frdm-k64f
+    mcu:
+        - mcu/freescale/mk64fn1m0xxx12
+
+```
+
+### MCU
+
+MCU record defines the basic information about the mcu and specific settings for each tool. As an example is shown the uvision settings for the lpc1768 mcu. The data can be obtain from the project files. Look for keys TargetOption in uvision project file.
+
+```
+mcu:
+    vendor:
+        - nxp
+    name:
+        - lpc1768
+    core:
+        - cortex-m3
+tools:
+    uvision:
+        TargetOption:
+            Device:
+                - LPC1768
+            Vendor:
+                - NXP
+            Cpu:
+                - IRAM(0x10000000-0x10007FFF) IRAM2(0x2007C000-0x20083FFF) IROM(0-0x7FFFF) CLOCK(12000000) CPUTYPE("Cortex-M3")
+            FlashDriverDll:
+                - UL2CM3(-O463 -S0 -C0 -FO7 -FD10000000 -FC800 -FN1 -FF0LPC_IAP_512 -FS00 -FL080000)
+            DeviceId:
+                - 4868
+            SFDFile:
+                - SFD\NXP\LPC176x5x\LPC176x5x.SFR
+```
+
+All this data must be manually written at the moment. We might add a parser for given project file, to generate valid record file for given tool.
+

--- a/mcu/freescale/mk20dx128xxx5.yaml
+++ b/mcu/freescale/mk20dx128xxx5.yaml
@@ -1,0 +1,22 @@
+mcu:
+    vendor:
+        - freescale
+    name:
+        - mk20dx128xxx5
+    core:
+        - cortex-m4f
+tools:
+    uvision:
+        TargetOption:
+            Device:
+                - MK20DX128xxx5
+            Vendor:
+                - Freescale Semiconductor
+            Cpu:
+                - IRAM(0x1FFFE000-0x1FFFFFFF) IRAM2(0x20000000-0x20001FFF) IROM(0x0-0x1FFFF) IROM2(0x10000000-0x10007FFF) CLOCK(12000000) CPUTYPE("Cortex-M4") ELITTLE
+            FlashDriverDll:
+                - ULP2CM3(-O2510 -S0 -C0 -FO15 -FD20000000 -FC800 -FN2 -FF0MK_P128_50MHZ -FS00 -FL020000 -FF1MK_D32_50MHZ -FS110000000 -FL108000)
+            DeviceId:
+                - 6206
+            SFDFile:
+                - SFD\Freescale\Kinetis\MK20D5.sfr

--- a/mcu/freescale/mk20dx128xxx5.yaml
+++ b/mcu/freescale/mk20dx128xxx5.yaml
@@ -5,7 +5,7 @@ mcu:
         - mk20dx128xxx5
     core:
         - cortex-m4f
-tools:
+tool_specific:
     uvision:
         TargetOption:
             Device:

--- a/mcu/freescale/mk64fn1m0xxx12.yaml
+++ b/mcu/freescale/mk64fn1m0xxx12.yaml
@@ -1,0 +1,22 @@
+mcu:
+    vendor:
+        - freescale
+    name:
+        - mk64fn1m0xxx12
+    core:
+        - cortex-m4f
+tools:
+    uvision:
+        TargetOption:
+            Device:
+                - MK64FN1M0xxx12
+            Vendor:
+                - Freescale Semiconductor
+            Cpu:
+                - IROM(0x00000000,0x100000) IRAM(0x20000000,0x30000) IRAM2(0x1FFF0000,0x10000) CPUTYPE("Cortex-M4") FPU2 CLOCK(120000000) ELITTLE
+            FlashDriverDll:
+                - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0MK_P1M0 -FS00 -FL0100000 -FP0($$Device:MK64FN1M0xxx12$Flash\MK_P1M0.FLM))
+            DeviceId:
+                - 7425
+            SFDFile:
+                - $$Device:MK64FN1M0xxx12$SVD\MK64F12.svd

--- a/mcu/freescale/mk64fn1m0xxx12.yaml
+++ b/mcu/freescale/mk64fn1m0xxx12.yaml
@@ -5,7 +5,7 @@ mcu:
         - mk64fn1m0xxx12
     core:
         - cortex-m4f
-tools:
+tool_specific:
     uvision:
         TargetOption:
             Device:

--- a/mcu/nxp/lpc1768.yaml
+++ b/mcu/nxp/lpc1768.yaml
@@ -5,7 +5,7 @@ mcu:
         - lpc1768
     core:
         - cortex-m3
-tools:
+tool_specific:
     uvision:
         TargetOption:
             Device:
@@ -23,7 +23,7 @@ tools:
     iar:
         OGChipSelectEditMenu:
             state:
-                - LPC1768	NXP LPC1768
+                - LPC1768 NXP LPC1768
         OGCoreOrChip:
             state:
                 - 1

--- a/mcu/nxp/lpc1768.yaml
+++ b/mcu/nxp/lpc1768.yaml
@@ -1,0 +1,63 @@
+mcu:
+    vendor:
+        - nxp
+    name:
+        - lpc1768
+    core:
+        - cortex-m3
+tools:
+    uvision:
+        TargetOption:
+            Device:
+                - LPC1768
+            Vendor:
+                - NXP
+            Cpu:
+                - IRAM(0x10000000-0x10007FFF) IRAM2(0x2007C000-0x20083FFF) IROM(0-0x7FFFF) CLOCK(12000000) CPUTYPE("Cortex-M3")
+            FlashDriverDll:
+                - UL2CM3(-O463 -S0 -C0 -FO7 -FD10000000 -FC800 -FN1 -FF0LPC_IAP_512 -FS00 -FL080000)
+            DeviceId:
+                - 4868
+            SFDFile:
+                - SFD\NXP\LPC176x5x\LPC176x5x.SFR
+    iar:
+        OGChipSelectEditMenu:
+            state:
+                - LPC1768	NXP LPC1768
+        OGCoreOrChip:
+            state:
+                - 1
+    coide:
+        Device:
+            manufacturerId:
+                - 7
+            manufacturerName:
+                - NXP
+            chipId:
+                - 165
+            chipName:
+                - LPC1768
+        DebugOption:
+            defaultAlgorithm:
+                - lpc17xx_512.elf
+        MemoryAreas:
+            IROM1:
+                size:
+                    - 0x00080000
+                startValue:
+                    - 0x00000000
+            IRAM1:
+                size:
+                    - 0x00008000
+                startValue:
+                    - 0x10000000
+            IROM2:
+                size:
+                    - 0x0
+                startValue:
+                    - 0x0
+            IRAM2:
+                size:
+                    - 0x00008000
+                startValue:
+                    - 0x2007C000

--- a/target/frdm-k20d50m.yaml
+++ b/target/frdm-k20d50m.yaml
@@ -1,0 +1,5 @@
+target:
+    name:
+        - frdm-k20d50m
+    mcu:
+        - mcu/freescale/mk20dx128xxx5

--- a/target/frdm-k64f.yaml
+++ b/target/frdm-k64f.yaml
@@ -1,0 +1,5 @@
+target:
+    name:
+        - frdm-k64f
+    mcu:
+        - mcu/freescale/mk64fn1m0xxx12

--- a/target/mbed-lpc1768.yaml
+++ b/target/mbed-lpc1768.yaml
@@ -1,0 +1,5 @@
+target:
+    name:
+        - mbed-lpc1768
+    mcu:
+        - mcu/nxp/lpc1768


### PR DESCRIPTION
An example:
target/frdm-k20d50m
target/myk20board #based on the same MCU so it reuses its definition
mcu/freescale/mk20dx128xxx5

My initial proposal for the tree in this repository. I believe scripts will be part of this repo, probably in the root? What I can think of, it's parser of this data, to get a valid target and its mcu def for given tool, list of supported targets, and in the long run a parser of project files, to get MCU definitions.

An example can be, provide your IDE already set with the MCU (uvproj for uvision for example), parse to get mcu def, create simple record (or add/create a new yaml record). 

Open for discussion
