### PR TITLE
Targets correction, target vs mcu - removal

### DIFF
--- a/project_generator_definitions/definitions.py
+++ b/project_generator_definitions/definitions.py
@@ -15,8 +15,9 @@
 import yaml
 import subprocess
 import logging
+import glob
 
-from os.path import join, normpath, splitext, isfile, dirname
+from os.path import join, normpath, splitext, isfile, dirname, basename
 from os import listdir, getcwd
 
 from .tools import UvisionDefinition, IARDefinitions, CoIDEdefinitions
@@ -28,13 +29,32 @@ def _load_record(file):
     project_file.close()
     return config
 
+class ProGenMcus:
+
+    def __init__(self):
+        mcu_files = glob.glob(join(dirname(__file__), 'mcu', '*', '*.yaml'))
+        self.mcus = {}
+        for m in mcu_files:
+            self.mcus[splitext(basename(m))[0]] = m
+
+    def get_mcus(self):
+        return list(self.mcus.keys())
+
+    def get_mcu_record(self, mcu):
+        if mcu in self.get_mcus():
+            mcu_path = self.mcus[mcu]
+            return _load_record(mcu_path)
+        else:
+            logging.info("Target not found")
+            return None
+
 class ProGenTargets:
 
     def __init__(self):
         self.targets = PROGENDEF_TARGETS
 
     def get_targets(self):
-        return self.targets.keys()
+        return list(self.targets.keys())
 
     def get_mcu_record(self, target):
         if target in self.get_targets():
@@ -46,7 +66,7 @@ class ProGenTargets:
             logging.info("Target not found")
             return None
 
-class ProGenDef(ProGenTargets):
+class ProGenDef:
 
     TOOL_SPECIFIC = {
         'uvision': UvisionDefinition,
@@ -56,7 +76,10 @@ class ProGenDef(ProGenTargets):
 
     def __init__(self, tool=None):
         """ Tool can be either tool_specific or None=only generic available """
-        ProGenTargets.__init__(self)
+        self.targets = ProGenTargets()
+        self.mcus = ProGenMcus()
+        # list of all mcu and targets. User can request any of these, we figure it out
+        self.targets_mcu_list = self.targets.get_targets() + self.mcus.get_mcus()
         self.definitions = None
         self.tool = None
         if tool != None:
@@ -66,10 +89,16 @@ class ProGenDef(ProGenTargets):
             except KeyError:
                 pass
 
+    def get_targets(self):
+        return self.targets.get_targets()
+
+    def get_mcus(self):
+        return self.mcus.get_mcus()
+
     def get_mcu_core(self, target):
-        if target not in self.get_targets():
+        if target not in self.targets_mcu_list:
             return None
-        mcu_record = self.get_mcu_record(target)
+        mcu_record = self.targets.get_mcu_record(target) if self.mcus.get_mcu_record(target) is None else self.mcus.get_mcu_record(target)
         try:
             return mcu_record['mcu']['core']
         except KeyError:
@@ -77,10 +106,10 @@ class ProGenDef(ProGenTargets):
 
     def get_tool_definition(self, target):
         """ Returns tool specific dic or None if it does not exist for defined tool """
-        if target not in self.get_targets():
+        if target not in self.targets_mcu_list:
             logging.debug("Target not found in definitions")
             return None
-        mcu_record = self.get_mcu_record(target)
+        mcu_record = self.targets.get_mcu_record(target) if self.mcus.get_mcu_record(target) is None else self.mcus.get_mcu_record(target)
         try:
             return mcu_record['tool_specific'][self.tool]
         except KeyError:
@@ -88,10 +117,10 @@ class ProGenDef(ProGenTargets):
 
     def is_supported(self, target):
         """ Returns True if target is supported by definitions """
-        if target.lower() not in self.get_targets():
+        if target.lower() not in self.targets_mcu_list:
             logging.debug("Target not found in definitions")
             return False
-        mcu_record = self.get_mcu_record(target)
+        mcu_record = self.targets.get_mcu_record(target) if self.mcus.get_mcu_record(target) is None else self.mcus.get_mcu_record(target)
         # Look at tool specific options which define tools supported for target
         # TODO: we might create a list of what tool requires
         if self.tool:

--- a/project_generator_definitions/definitions.py
+++ b/project_generator_definitions/definitions.py
@@ -20,8 +20,7 @@ from os.path import join, normpath, splitext, isfile, dirname
 from os import listdir, getcwd
 
 from .tools import UvisionDefinition, IARDefinitions, CoIDEdefinitions
-
-TEMPLATE_DIR_TARGET = join(dirname(__file__), 'target')
+from .target.targets import PROGENDEF_TARGETS
 
 def _load_record(file):
     project_file = open(file)
@@ -32,23 +31,20 @@ def _load_record(file):
 class ProGenTargets:
 
     def __init__(self):
-        self.targets = [splitext(f)[0] for f in listdir(TEMPLATE_DIR_TARGET) if isfile(join(TEMPLATE_DIR_TARGET,f))]
+        self.targets = [PROGENDEF_TARGETS.keys()]
 
     def get_targets(self):
         return self.targets
 
-    def get_target_record(self, target):
-        target_path = join(TEMPLATE_DIR_TARGET, target + '.yaml')
-        return _load_record(target_path)
-
     def get_mcu_record(self, target):
-        target_path = join(TEMPLATE_DIR_TARGET, target + '.yaml')
-        target_record = _load_record(target_path)
-        mcu_path = target_record['target']['mcu']
-        mcu_path = normpath(mcu_path[0])
-        mcu_path = join(dirname(__file__), mcu_path) + '.yaml'
-        return _load_record(mcu_path)
-
+        if target in PROGENDEF_TARGETS:
+            mcu_path = PROGENDEF_TARGETS[target]
+            mcu_path = normpath(mcu_path[0])
+            mcu_path = join(dirname(__file__), mcu_path) + '.yaml'
+            return _load_record(mcu_path)
+        else:
+            logging.info("Target not found")
+            return None
 
 class ProGenDef(ProGenTargets):
 

--- a/project_generator_definitions/definitions.py
+++ b/project_generator_definitions/definitions.py
@@ -31,15 +31,15 @@ def _load_record(file):
 class ProGenTargets:
 
     def __init__(self):
-        self.targets = [PROGENDEF_TARGETS.keys()]
+        self.targets = PROGENDEF_TARGETS
 
     def get_targets(self):
-        return self.targets
+        return self.targets.keys()
 
     def get_mcu_record(self, target):
-        if target in PROGENDEF_TARGETS:
-            mcu_path = PROGENDEF_TARGETS[target]
-            mcu_path = normpath(mcu_path[0])
+        if target in self.get_targets():
+            mcu_path = self.targets[target]
+            mcu_path = normpath(mcu_path)
             mcu_path = join(dirname(__file__), mcu_path) + '.yaml'
             return _load_record(mcu_path)
         else:
@@ -67,7 +67,7 @@ class ProGenDef(ProGenTargets):
                 pass
 
     def get_mcu_core(self, target):
-        if target not in self.targets:
+        if target not in self.get_targets():
             return None
         mcu_record = self.get_mcu_record(target)
         try:
@@ -77,7 +77,7 @@ class ProGenDef(ProGenTargets):
 
     def get_tool_definition(self, target):
         """ Returns tool specific dic or None if it does not exist for defined tool """
-        if target not in self.targets:
+        if target not in self.get_targets():
             logging.debug("Target not found in definitions")
             return None
         mcu_record = self.get_mcu_record(target)
@@ -88,7 +88,7 @@ class ProGenDef(ProGenTargets):
 
     def is_supported(self, target):
         """ Returns True if target is supported by definitions """
-        if target.lower() not in self.targets:
+        if target.lower() not in self.get_targets():
             logging.debug("Target not found in definitions")
             return False
         mcu_record = self.get_mcu_record(target)

--- a/project_generator_definitions/target/__init__.py
+++ b/project_generator_definitions/target/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/project_generator_definitions/target/arch-ble.yaml
+++ b/project_generator_definitions/target/arch-ble.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - arch-ble
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/arch-pro.yaml
+++ b/project_generator_definitions/target/arch-pro.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - arch-pro
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/atsam3u2c.yaml
+++ b/project_generator_definitions/target/atsam3u2c.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - atsam3u2c
-    mcu:
-        - mcu/atmel/atsam3u2c

--- a/project_generator_definitions/target/cortex-m0.yaml
+++ b/project_generator_definitions/target/cortex-m0.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - cortex-m0
-    mcu:
-        - mcu/arm/cortex-m0

--- a/project_generator_definitions/target/cortex-m3.yaml
+++ b/project_generator_definitions/target/cortex-m3.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - cortex-m3
-    mcu:
-        - mcu/arm/cortex-m3

--- a/project_generator_definitions/target/cortex-m4-fpu.yaml
+++ b/project_generator_definitions/target/cortex-m4-fpu.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - cortex-m4-fpu
-    mcu:
-        - mcu/arm/cortex-m4-fpu

--- a/project_generator_definitions/target/cortex-m4.yaml
+++ b/project_generator_definitions/target/cortex-m4.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - cortex-m4
-    mcu:
-        - mcu/arm/cortex-m4

--- a/project_generator_definitions/target/cortex-m7.yaml
+++ b/project_generator_definitions/target/cortex-m7.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - cortex-m7
-    mcu:
-        - mcu/arm/cortex-m7

--- a/project_generator_definitions/target/dfcm-nnn40.yaml
+++ b/project_generator_definitions/target/dfcm-nnn40.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - dfcm-nnn40
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/disco-f334c8.yaml
+++ b/project_generator_definitions/target/disco-f334c8.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-f334c8
-    mcu:
-        - mcu/st/stm32f334x8

--- a/project_generator_definitions/target/disco-f334r8.yaml
+++ b/project_generator_definitions/target/disco-f334r8.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-f334r8
-    mcu:
-        - mcu/st/stm32f334x8

--- a/project_generator_definitions/target/disco-f407vg.yaml
+++ b/project_generator_definitions/target/disco-f407vg.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-f407vg
-    mcu:
-        - mcu/st/stm32f401xe

--- a/project_generator_definitions/target/disco-f746ng.yaml
+++ b/project_generator_definitions/target/disco-f746ng.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-f334c8
-    mcu:
-        - mcu/st/stm32f746ng

--- a/project_generator_definitions/target/disco-l053c8.yaml
+++ b/project_generator_definitions/target/disco-l053c8.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-l053c8
-    mcu:
-        - mcu/st/stm32l053x8

--- a/project_generator_definitions/target/disco-l476ng.yaml
+++ b/project_generator_definitions/target/disco-l476ng.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - disco-l476vg
-    mcu:
-        - mcu/st/stm32l476vg

--- a/project_generator_definitions/target/efm32gg-stk.yaml
+++ b/project_generator_definitions/target/efm32gg-stk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - efm32gg-stk
-    mcu:
-        - mcu/siliconlabs/efm32gg990f1024

--- a/project_generator_definitions/target/efm32hg-stk.yaml
+++ b/project_generator_definitions/target/efm32hg-stk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - efm32hg-stk
-    mcu:
-        - mcu/siliconlabs/efm32hg322f64

--- a/project_generator_definitions/target/efm32lg-stk.yaml
+++ b/project_generator_definitions/target/efm32lg-stk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - efm32lg-stk
-    mcu:
-        - mcu/siliconlabs/efm32lg990f256

--- a/project_generator_definitions/target/efm32wg-stk.yaml
+++ b/project_generator_definitions/target/efm32wg-stk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - efm32wg-stk
-    mcu:
-        - mcu/siliconlabs/efm32wg990f256

--- a/project_generator_definitions/target/efm32zg-stk.yaml
+++ b/project_generator_definitions/target/efm32zg-stk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - efm32zg-stk
-    mcu:
-        - mcu/siliconlabs/efm32zg222f32

--- a/project_generator_definitions/target/frdm-k20d50m.yaml
+++ b/project_generator_definitions/target/frdm-k20d50m.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-k20d50m
-    mcu:
-        - mcu/freescale/mk20dx128xxx5

--- a/project_generator_definitions/target/frdm-k22f.yaml
+++ b/project_generator_definitions/target/frdm-k22f.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-k22f
-    mcu:
-        - mcu/freescale/mk22dn512xxx5

--- a/project_generator_definitions/target/frdm-k64f.yaml
+++ b/project_generator_definitions/target/frdm-k64f.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-k64f
-    mcu:
-        - mcu/freescale/mk64fn1m0xxx12

--- a/project_generator_definitions/target/frdm-kl05z.yaml
+++ b/project_generator_definitions/target/frdm-kl05z.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-kl05z
-    mcu:
-        - mcu/freescale/mkl05z32xxx4

--- a/project_generator_definitions/target/frdm-kl25z.yaml
+++ b/project_generator_definitions/target/frdm-kl25z.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-kl25z
-    mcu:
-        - mcu/freescale/mkl25z128xxx4

--- a/project_generator_definitions/target/frdm-kl43z.yaml
+++ b/project_generator_definitions/target/frdm-kl43z.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-kl43z
-    mcu:
-        - mcu/freescale/mkl43z256xxx4

--- a/project_generator_definitions/target/frdm-kl46z.yaml
+++ b/project_generator_definitions/target/frdm-kl46z.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-kl46z
-    mcu:
-        - mcu/freescale/mkl46z256xxx4

--- a/project_generator_definitions/target/hrm1017.yaml
+++ b/project_generator_definitions/target/hrm1017.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - hrm1017
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/k64f.yaml
+++ b/project_generator_definitions/target/k64f.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - frdm-k64f
-    mcu:
-        - mcu/freescale/mk64fn1m0xxx12

--- a/project_generator_definitions/target/lpc11u35-501.yaml
+++ b/project_generator_definitions/target/lpc11u35-501.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - lpc11u35-501
-    mcu:
-        - mcu/nxp/lpc11u35-501

--- a/project_generator_definitions/target/max32600.yaml
+++ b/project_generator_definitions/target/max32600.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - max32600
-    mcu:
-        - mcu/maxim/max32600x85

--- a/project_generator_definitions/target/maxwsnenv.yaml
+++ b/project_generator_definitions/target/maxwsnenv.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - max32600
-    mcu:
-        - mcu/maxim/max32600x85

--- a/project_generator_definitions/target/mbed-lpc1768.yaml
+++ b/project_generator_definitions/target/mbed-lpc1768.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mbed-lpc1768
-    mcu:
-        - mcu/nxp/lpc1768

--- a/project_generator_definitions/target/mk20dx128xxx5.yaml
+++ b/project_generator_definitions/target/mk20dx128xxx5.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mk20dx128xxx5
-    mcu:
-        - mcu/freescale/mk20dx128xxx5

--- a/project_generator_definitions/target/mk22dn512xxx5.yaml
+++ b/project_generator_definitions/target/mk22dn512xxx5.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mk22dn512xxx5
-    mcu:
-        - mcu/freescale/mk22dn512xxx5

--- a/project_generator_definitions/target/mkit.yaml
+++ b/project_generator_definitions/target/mkit.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mkit
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/mkl26z128xxx4.yaml
+++ b/project_generator_definitions/target/mkl26z128xxx4.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mkl26z128xxx4
-    mcu:
-        - mcu/freescale/mkl26z128xxx4

--- a/project_generator_definitions/target/mkl27z256xxx4.yaml
+++ b/project_generator_definitions/target/mkl27z256xxx4.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mkl27z256xxx4
-    mcu:
-        - mcu/freescale/mkl27z256xxx4

--- a/project_generator_definitions/target/nrf51-dk.yaml
+++ b/project_generator_definitions/target/nrf51-dk.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nrf51-dk
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/nrf51-dongle.yaml
+++ b/project_generator_definitions/target/nrf51-dongle.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nrf51-dongle
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/nu-nuc472-nutiny.yaml
+++ b/project_generator_definitions/target/nu-nuc472-nutiny.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nu-nuc472-nutiny
-    mcu:
-        - mcu/nuvoton/nuc472hi8ae

--- a/project_generator_definitions/target/nucleo-f030r8.yaml
+++ b/project_generator_definitions/target/nucleo-f030r8.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f030r8
-    mcu:
-        - mcu/st/stm32f030x8

--- a/project_generator_definitions/target/nucleo-f070rb.yaml
+++ b/project_generator_definitions/target/nucleo-f070rb.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f070rb
-    mcu:
-        - mcu/st/stm32f070rb

--- a/project_generator_definitions/target/nucleo-f072rb.yaml
+++ b/project_generator_definitions/target/nucleo-f072rb.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f072rb
-    mcu:
-        - mcu/st/stm32f072rb

--- a/project_generator_definitions/target/nucleo-f091rc.yaml
+++ b/project_generator_definitions/target/nucleo-f091rc.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f091rc
-    mcu:
-        - mcu/st/stm32f091rc

--- a/project_generator_definitions/target/nucleo-f103rb .yaml
+++ b/project_generator_definitions/target/nucleo-f103rb .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f103rb
-    mcu:
-        - mcu/st/stm32f103xb

--- a/project_generator_definitions/target/nucleo-f302r8 .yaml
+++ b/project_generator_definitions/target/nucleo-f302r8 .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f302r8
-    mcu:
-        - mcu/st/stm32f302x8

--- a/project_generator_definitions/target/nucleo-f303re .yaml
+++ b/project_generator_definitions/target/nucleo-f303re .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f303re
-    mcu:
-        - mcu/st/stm32f303xe

--- a/project_generator_definitions/target/nucleo-f334r8 .yaml
+++ b/project_generator_definitions/target/nucleo-f334r8 .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f334r8
-    mcu:
-        - mcu/st/stm32f334x8

--- a/project_generator_definitions/target/nucleo-f401re .yaml
+++ b/project_generator_definitions/target/nucleo-f401re .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f401re
-    mcu:
-        - mcu/st/stm32f401xe

--- a/project_generator_definitions/target/nucleo-f411re .yaml
+++ b/project_generator_definitions/target/nucleo-f411re .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f411re
-    mcu:
-        - mcu/st/stm32f411re

--- a/project_generator_definitions/target/nucleo-f446re .yaml
+++ b/project_generator_definitions/target/nucleo-f446re .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-f446re
-    mcu:
-        - mcu/st/stm32f446re

--- a/project_generator_definitions/target/nucleo-l053r8 .yaml
+++ b/project_generator_definitions/target/nucleo-l053r8 .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-l053r8
-    mcu:
-        - mcu/st/stm32l053x8

--- a/project_generator_definitions/target/nucleo-l073rz .yaml
+++ b/project_generator_definitions/target/nucleo-l073rz .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-l073rz
-    mcu:
-        - mcu/st/stm32l073xz

--- a/project_generator_definitions/target/nucleo-l152re .yaml
+++ b/project_generator_definitions/target/nucleo-l152re .yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - nucleo-l152re
-    mcu:
-        - mcu/st/stm32l152xe

--- a/project_generator_definitions/target/odin-w2.yaml
+++ b/project_generator_definitions/target/odin-w2.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - odin-w2
-    mcu:
-        - mcu/st/stm32f439zitx

--- a/project_generator_definitions/target/seed-tinyble.yaml
+++ b/project_generator_definitions/target/seed-tinyble.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - seed-tinyble
-    mcu:
-        - mcu/nordic/nrf51

--- a/project_generator_definitions/target/stk3700-gcc.yaml
+++ b/project_generator_definitions/target/stk3700-gcc.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - stk3700-gcc
-    mcu:
-        - mcu/siliconlabs/efm32gg990f1024

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -29,7 +29,7 @@ PROGENDEF_TARGETS = {
     'efm32lg-stk':'mcu/siliconlabs/efm32lg990f256',
     'frdm-k20d50m':'mcu/freescale/mk20dx128xxx5',
     'frdm-k22f':'mcu/freescale/mk22dn512xxx5',
-    'frdm-k64f': 'mcu/freescale/mk64f',
+    'frdm-k64f': 'mcu/freescale/mk64fn1m0xxx12',
     'frdm-kl05z':'mcu/freescale/mkl05z32xxx4',
     'frdm-kl25z':'mcu/freescale/mkl25z128xxx4',
     'frdm-kl43z':'mcu/freescale/mkl43z256xxx4',

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Targets mapping to mcu
+# should be target name: path to mcu yaml file
 PROGENDEF_TARGETS = {
     'arch-ble': 'mcu/nordic/nrf51',
     'arch-pro': 'mcu/nordic/nrf51',

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -1,0 +1,63 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROGENDEF_TARGETS = {
+    'arch-ble': 'mcu/nordic/nrf51',
+    'arch-pro': 'mcu/nordic/nrf51',
+    'dfcm-nnn40': 'mcu/nordic/nrf51',
+    'mbed-lpc1768': 'mcu/nxp/lpc1768',
+    'disco-f334c8':'mcu/st/stm32f334x8',
+    'disco-f407vg':'mcu/st/stm32f401xe',
+    'disco-f746ng':'mcu/st/stm32f746ng',
+    'disco-l053c8':'mcu/st/stm32l053x8',
+    'disco-l476vg':'mcu/st/stm32l476vg',
+    'efm32gg-stk':'mcu/siliconlabs/efm32gg990f1024',
+    'efm32hg-stk':'mcu/siliconlabs/efm32hg322f64',
+    'efm32wg-stk':'mcu/siliconlabs/efm32wg990f256',
+    'efm32zg-stk':'mcu/siliconlabs/efm32zg222f32',
+    'efm32lg-stk':'mcu/siliconlabs/efm32lg990f256',
+    'frdm-k20d50m':'mcu/freescale/mk20dx128xxx5',
+    'frdm-k22f':'mcu/freescale/mk22dn512xxx5',
+    'frdm-k64f': 'mcu/freescale/mk64f',
+    'frdm-kl05z':'mcu/freescale/mkl05z32xxx4',
+    'frdm-kl25z':'mcu/freescale/mkl25z128xxx4',
+    'frdm-kl43z':'mcu/freescale/mkl43z256xxx4',
+    'frdm-kl46z':'mcu/freescale/mkl46z256xxx4',
+    'hrm1017':'mcu/nordic/nrf51',
+    'max32600':'mcu/maxim/max32600x85',
+    'max32600':'mcu/maxim/max32600x85',
+    'mbed-lpc11u24':'mcu/nxp/lpc11u24fbd64_401',
+    'mbed-lpc1768':'mcu/nxp/lpc1768',
+    'mkit':'mcu/nordic/nrf51',
+    'nrf51-dk':'mcu/nordic/nrf51',
+    'nrf51-dongle':'mcu/nordic/nrf51',
+    'nu-nuc472-nutiny':'mcu/nuvoton/nuc472hi8ae',
+    'nucleo-f030r8':'mcu/st/stm32f030x8',
+    'nucleo-f070rb':'mcu/st/stm32f070rb',
+    'nucleo-f072rb':'mcu/st/stm32f072rb',
+    'nucleo-f103rb':'mcu/st/stm32f103xb',
+    'nucleo-f091rc':'mcu/st/stm32f091rc',
+    'nucleo-f302r8':'mcu/st/stm32f302x8',
+    'nucleo-f303re':'mcu/st/stm32f303xe',
+    'nucleo-f334r8':'mcu/st/stm32f334x8',
+    'nucleo-f401re':'mcu/st/stm32f401xe',
+    'nucleo-f411re':'mcu/st/stm32f411re',
+    'nucleo-f446re':'mcu/st/stm32f446re',
+    'nucleo-l073rz':'mcu/st/stm32l073xz',
+    'nucleo-l152re':'mcu/st/stm32l152xe',
+    'ublox-c027':'mcu/nxp/lpc1768',
+    'seed-tinyble':'mcu/nordic/nrf51',
+    'stk3700-gcc':'mcu/siliconlabs/efm32gg990f1024',
+    'odin-w2':'mcu/st/stm32f439zitx',
+}

--- a/project_generator_definitions/target/ublox-c027.yaml
+++ b/project_generator_definitions/target/ublox-c027.yaml
@@ -1,5 +1,0 @@
-target:
-    name:
-        - mbed-lpc1768
-    mcu:
-        - mcu/nxp/lpc1768

--- a/tests/test_mcus.py
+++ b/tests/test_mcus.py
@@ -1,0 +1,67 @@
+# Copyright 2015 0xc0170
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+
+from project_generator_definitions.definitions import ProGenMcus
+
+class TestAllMcus(TestCase):
+
+    """test all targets"""
+
+    def setUp(self):
+        self.progen_mcus = ProGenMcus()
+        self.mcus_list = self.progen_mcus.get_mcus()
+
+    def test_mcu_validity(self):
+        # Check for required info in mcu
+        for mcu in self.mcus_list:
+            mcu_rec = self.progen_mcus.get_mcu_record(mcu)
+            assert mcu_rec['mcu']
+            assert mcu_rec['mcu']['name'][0]
+            assert mcu_rec['mcu']['core'][0]
+
+    def test_mcu_tool_specific_uvision_validity(self):
+        for target in self.mcus_list:
+            mcu = self.progen_mcus.get_mcu_record(target)
+            if mcu['tool_specific']:
+                try:
+                    for tool in mcu['tool_specific'].keys():
+                        if tool == 'uvision':
+                            assert mcu['tool_specific']['uvision']['TargetOption']
+                            assert mcu['tool_specific']['uvision']['TargetOption']['Device'][0]
+                            # DeviceId might be 0
+                            assert mcu['tool_specific']['uvision']['TargetOption']['DeviceId'][0] != -1
+                except KeyError:
+                    pass
+
+    def test_mcu_tool_specific_iar_validity(self):
+        for mcu in self.mcus_list:
+            mcu = self.progen_mcus.get_mcu_record(mcu)
+            if mcu['tool_specific']:
+                for tool in mcu['tool_specific'].keys():
+                    if tool == 'iar' :
+                        assert mcu['tool_specific']['iar']['OGChipSelectEditMenu']['state'][0]
+                        assert mcu['tool_specific']['iar']['OGCoreOrChip']['state'][0]
+
+    def test_mcu_tool_specific_coide_validity(self):
+        for mcu in self.mcus_list:
+            mcu = self.progen_mcus.get_mcu_record(mcu)
+            if mcu['tool_specific']:
+                for tool in mcu['tool_specific'].keys():
+                    if tool == 'coide' :
+                        assert mcu['tool_specific']['coide']['Device']['manufacturerName'][0]
+                        assert mcu['tool_specific']['coide']['Device']['chipId'][0]
+                        assert mcu['tool_specific']['coide']['Device']['chipName'][0]
+                        assert mcu['tool_specific']['coide']['DebugOption']['defaultAlgorithm'][0]

--- a/tests/test_targets/test_targets.py
+++ b/tests/test_targets/test_targets.py
@@ -15,6 +15,7 @@
 from unittest import TestCase
 
 from project_generator_definitions.definitions import ProGenTargets
+from project_generator_definitions.target.targets import PROGENDEF_TARGETS
 
 class TestAllTargets(TestCase):
 
@@ -27,9 +28,8 @@ class TestAllTargets(TestCase):
     def test_targets_validity(self):
         # Cehck for required info for targets
         for target in self.targets_list:
-            record = self.progen_target.get_target_record(target)
-            assert record['target']['name'][0]
-            assert record['target']['mcu'][0]
+            mcu_path = PROGENDEF_TARGETS[target]
+            assert mcu_path
 
     def test_targets_mcu_validity(self):
         # Check for required info in mcu


### PR DESCRIPTION
There was API only to get targets, targets were in YAML, thus we added some targets which were just MCU. This should fix it

There is a new mcu class, which defines progen mcu API, then we have progen target.

Public ProgenDef has a logic to check both targets and mcus to get a proper definition. Thus for a user, it does not matter if they request lpc1768 or mbed-lpc1768, the proper mcu definition will be returned.

This should not break anything, but I would prefer to release v0.2.x with this API improvements.
