### PR TITLE
Debugger support for targets addition

### DIFF
--- a/project_generator_definitions/definitions.py
+++ b/project_generator_definitions/definitions.py
@@ -57,12 +57,19 @@ class ProGenTargets:
 
     def get_mcu_record(self, target):
         if target in self.get_targets():
-            mcu_path = self.targets[target]
+            mcu_path = self.targets[target]['mcu']
             mcu_path = normpath(mcu_path)
             mcu_path = join(dirname(__file__), mcu_path) + '.yaml'
             return _load_record(mcu_path)
         else:
             return None
+
+    def get_debugger(self, target):
+        try:
+            debugger = self.targets[target]['debugger']
+        except KeyError:
+            debugger = None
+        return debugger
 
 class ProGenDef:
 
@@ -133,6 +140,9 @@ class ProGenDef:
         else:
             # supports generic part (mcu part)
             return True
+
+    def get_debugger(self, target):
+        return self.targets.get_debugger(target)
 
     def mcu_create(self, mcu_name, template_file):
         if self.definitions == None:

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -15,6 +15,7 @@
 # Targets mapping to mcu
 # should be : target_name['mcu'] path to mcu file
 #             target_name['debugger'] debugger to be set up, not defined - None
+#                                     jtag/swd interface
 PROGENDEF_TARGETS = {
     'arch-ble': {
         'mcu':'mcu/nordic/nrf51822',
@@ -45,23 +46,38 @@ PROGENDEF_TARGETS = {
     },
     'efm32gg-stk': {
         'mcu':'mcu/siliconlabs/efm32gg990f1024',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'efm32hg-stk': {
         'mcu':'mcu/siliconlabs/efm32hg322f64',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'efm32wg-stk': {
         'mcu':'mcu/siliconlabs/efm32wg990f256',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'efm32zg-stk': {
         'mcu':'mcu/siliconlabs/efm32zg222f32',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'efm32lg-stk': {
         'mcu':'mcu/siliconlabs/efm32lg990f256',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'frdm-k20d50m': {
         'mcu':'mcu/freescale/mk20dx128xxx5',
@@ -158,7 +174,10 @@ PROGENDEF_TARGETS = {
     },
     'stk3700-gcc': {
         'mcu':'mcu/siliconlabs/efm32gg990f1024',
-        'debugger': 'j-link',
+        'debugger': {
+            'name': 'j-link',
+            'interface': 'swd',
+        }
     },
     'odin-w2': {
         'mcu':'mcu/st/stm32f439zitx',

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -13,54 +13,154 @@
 # limitations under the License.
 
 # Targets mapping to mcu
-# should be target name: path to mcu yaml file
+# should be : target_name['mcu'] path to mcu file
+#             target_name['debugger'] debugger to be set up, not defined - None
 PROGENDEF_TARGETS = {
-    'arch-ble': 'mcu/nordic/nrf51822',
-    'arch-pro': 'mcu/nordic/nrf51822',
-    'dfcm-nnn40': 'mcu/nordic/nrf51822',
-    'mbed-lpc1768': 'mcu/nxp/lpc1768',
-    'disco-f334c8':'mcu/st/stm32f334x8',
-    'disco-f407vg':'mcu/st/stm32f401xe',
-    'disco-f746ng':'mcu/st/stm32f746ng',
-    'disco-l053c8':'mcu/st/stm32l053x8',
-    'disco-l476vg':'mcu/st/stm32l476vg',
-    'efm32gg-stk':'mcu/siliconlabs/efm32gg990f1024',
-    'efm32hg-stk':'mcu/siliconlabs/efm32hg322f64',
-    'efm32wg-stk':'mcu/siliconlabs/efm32wg990f256',
-    'efm32zg-stk':'mcu/siliconlabs/efm32zg222f32',
-    'efm32lg-stk':'mcu/siliconlabs/efm32lg990f256',
-    'frdm-k20d50m':'mcu/freescale/mk20dx128xxx5',
-    'frdm-k22f':'mcu/freescale/mk22dn512xxx5',
-    'frdm-k64f': 'mcu/freescale/mk64fn1m0xxx12',
-    'k64f': 'mcu/freescale/mk64fn1m0xxx12',
-    'frdm-kl05z':'mcu/freescale/mkl05z32xxx4',
-    'frdm-kl25z':'mcu/freescale/mkl25z128xxx4',
-    'frdm-kl43z':'mcu/freescale/mkl43z256xxx4',
-    'frdm-kl46z':'mcu/freescale/mkl46z256xxx4',
-    'hrm1017':'mcu/nordic/nrf51822',
-    'max32600':'mcu/maxim/max32600x85',
-    'max32600':'mcu/maxim/max32600x85',
-    'mbed-lpc11u24':'mcu/nxp/lpc11u24_201',
-    'mbed-lpc1768':'mcu/nxp/lpc1768',
-    'mkit':'mcu/nordic/nrf51822',
-    'nrf51-dk':'mcu/nordic/nrf51822',
-    'nrf51-dongle':'mcu/nordic/nrf51822',
-    'nu-nuc472-nutiny':'mcu/nuvoton/nuc472hi8ae',
-    'nucleo-f030r8':'mcu/st/stm32f030x8',
-    'nucleo-f070rb':'mcu/st/stm32f070rb',
-    'nucleo-f072rb':'mcu/st/stm32f072rb',
-    'nucleo-f103rb':'mcu/st/stm32f103xb',
-    'nucleo-f091rc':'mcu/st/stm32f091rc',
-    'nucleo-f302r8':'mcu/st/stm32f302x8',
-    'nucleo-f303re':'mcu/st/stm32f303xe',
-    'nucleo-f334r8':'mcu/st/stm32f334x8',
-    'nucleo-f401re':'mcu/st/stm32f401xe',
-    'nucleo-f411re':'mcu/st/stm32f411re',
-    'nucleo-f446re':'mcu/st/stm32f446re',
-    'nucleo-l073rz':'mcu/st/stm32l073xz',
-    'nucleo-l152re':'mcu/st/stm32l152xe',
-    'ublox-c027':'mcu/nxp/lpc1768',
-    'seed-tinyble':'mcu/nordic/nrf51822',
-    'stk3700-gcc':'mcu/siliconlabs/efm32gg990f1024',
-    'odin-w2':'mcu/st/stm32f439zitx',
+    'arch-ble': {
+        'mcu':'mcu/nordic/nrf51822',
+     },
+    'arch-pro': {
+        'mcu':'mcu/nordic/nrf51822',
+     },
+    'dfcm-nnn40': {
+        'mcu':'mcu/nordic/nrf51822',
+     },
+    'mbed-lpc1768': {
+        'mcu':'mcu/nxp/lpc1768',
+     },
+    'disco-f334c8': {
+        'mcu':'mcu/st/stm32f334x8',
+    },
+    'disco-f407vg': {
+        'mcu':'mcu/st/stm32f401xe',
+    },
+    'disco-f746ng': {
+        'mcu':'mcu/st/stm32f746ng',
+    },
+    'disco-l053c8': {
+        'mcu':'mcu/st/stm32l053x8',
+    },
+    'disco-l476vg': {
+        'mcu':'mcu/st/stm32l476vg',
+    },
+    'efm32gg-stk': {
+        'mcu':'mcu/siliconlabs/efm32gg990f1024',
+        'debugger': 'j-link',
+    },
+    'efm32hg-stk': {
+        'mcu':'mcu/siliconlabs/efm32hg322f64',
+        'debugger': 'j-link',
+    },
+    'efm32wg-stk': {
+        'mcu':'mcu/siliconlabs/efm32wg990f256',
+        'debugger': 'j-link',
+    },
+    'efm32zg-stk': {
+        'mcu':'mcu/siliconlabs/efm32zg222f32',
+        'debugger': 'j-link',
+    },
+    'efm32lg-stk': {
+        'mcu':'mcu/siliconlabs/efm32lg990f256',
+        'debugger': 'j-link',
+    },
+    'frdm-k20d50m': {
+        'mcu':'mcu/freescale/mk20dx128xxx5',
+    },
+    'frdm-k22f': {
+        'mcu':'mcu/freescale/mk22dn512xxx5',
+    },
+    'frdm-k64f': {
+        'mcu':'mcu/freescale/mk64fn1m0xxx12',
+     },
+    'k64f': {
+        'mcu':'mcu/freescale/mk64fn1m0xxx12',
+     },
+    'frdm-kl05z': {
+        'mcu':'mcu/freescale/mkl05z32xxx4',
+    },
+    'frdm-kl25z': {
+        'mcu':'mcu/freescale/mkl25z128xxx4',
+    },
+    'frdm-kl43z': {
+        'mcu':'mcu/freescale/mkl43z256xxx4',
+    },
+    'frdm-kl46z': {
+        'mcu':'mcu/freescale/mkl46z256xxx4',
+    },
+    'hrm1017': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
+    'max32600': {
+        'mcu':'mcu/maxim/max32600x85',
+    },
+    'max32600': {
+        'mcu':'mcu/maxim/max32600x85',
+    },
+    'mbed-lpc11u24': {
+        'mcu':'mcu/nxp/lpc11u24_201',
+    },
+    'mkit': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
+    'nrf51-dk': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
+    'nrf51-dongle': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
+    'nu-nuc472-nutiny': {
+        'mcu':'mcu/nuvoton/nuc472hi8ae',
+    },
+    'nucleo-f030r8': {
+        'mcu':'mcu/st/stm32f030x8',
+    },
+    'nucleo-f070rb': {
+        'mcu':'mcu/st/stm32f070rb',
+    },
+    'nucleo-f072rb': {
+        'mcu':'mcu/st/stm32f072rb',
+    },
+    'nucleo-f103rb': {
+        'mcu':'mcu/st/stm32f103xb',
+    },
+    'nucleo-f091rc': {
+        'mcu':'mcu/st/stm32f091rc',
+    },
+    'nucleo-f302r8': {
+        'mcu':'mcu/st/stm32f302x8',
+    },
+    'nucleo-f303re': {
+        'mcu':'mcu/st/stm32f303xe',
+    },
+    'nucleo-f334r8': {
+        'mcu':'mcu/st/stm32f334x8',
+    },
+    'nucleo-f401re': {
+        'mcu':'mcu/st/stm32f401xe',
+    },
+    'nucleo-f411re': {
+        'mcu':'mcu/st/stm32f411re',
+    },
+    'nucleo-f446re': {
+        'mcu':'mcu/st/stm32f446re',
+    },
+    'nucleo-l073rz': {
+        'mcu':'mcu/st/stm32l073xz',
+    },
+    'nucleo-l152re': {
+        'mcu':'mcu/st/stm32l152xe',
+    },
+    'ublox-c027': {
+        'mcu':'mcu/nxp/lpc1768',
+    },
+    'seed-tinyble': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
+    'stk3700-gcc': {
+        'mcu':'mcu/siliconlabs/efm32gg990f1024',
+        'debugger': 'j-link',
+    },
+    'odin-w2': {
+        'mcu':'mcu/st/stm32f439zitx',
+    },
 }


### PR DESCRIPTION
Each target defines mcu (mandatory) and can define debugger.

```
 'efm32lg-stk': {
    'mcu':'mcu/siliconlabs/efm32lg990f256',
    'debugger': 'j-link',
},
```
