### PR TITLE
IAR - fileversion 2 update

### DIFF
--- a/project_generator_definitions/mcu/st/stm32f746zg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746zg.yaml
@@ -7,6 +7,24 @@ mcu:
     - st
 tool_specific:
     iar:
+        CoreVariant:
+            state:
+            - 41
+        FPU2:
+            state:
+            - 6
+        GFPUCoreSlave2:
+            state:
+            - 41
+        GBECoreSlave:
+            state:
+            - 41
+        NEON:
+            state:
+            - 0
+        NrRegs:
+            state:
+            - 1
         OGChipSelectEditMenu:
             state:
             - STM32F746ZG ST STM32F746ZG

--- a/project_generator_definitions/tools.py
+++ b/project_generator_definitions/tools.py
@@ -139,33 +139,54 @@ class IARDefinitions:
         index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'OGChipSelectEditMenu')
         OGChipSelectEditMenu = configuration['settings'][index_general]['data']['option'][index_option]
         mcu['tool_specific']['iar']['OGChipSelectEditMenu']['state'].append(OGChipSelectEditMenu['state'].replace('\t', ' ', 1))
+        # we keep this as the internal version. FPU - version 1, FPU2 version 2. 
+        # TODO:We shall look at IAR versioning to get this right
+        fileVersion = 1
         # It can be either FPU or FPU2
         try:
             index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'FPU2')
             FPU2 = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['FPU2'] = { 'state': [FPU2['state']] }
+            mcu['tool_specific']['iar']['FPU2'] = { 'state': [int(FPU2['state'])] }
+            fileVersion = 2
         except TypeError:
             pass
         try:
             index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'FPU')
             FPU = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['FPU'] = { 'state': [FPU['state']] }
-        except TypeError:
-            pass
-        # TODO: We shall look at this settings and group them somehow (=architecture)
-        try:
-            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NrRegs')
-            NrRegs = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['NrRegs'] = { 'state': [NrRegs['state']] }
-        except TypeError:
-            pass
-        try:
-            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NEON')
-            NEON = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['NEON'] = { 'state': [NEON['state']] }
+            mcu['tool_specific']['iar']['FPU'] = { 'state': [int(FPU['state'])] }
         except TypeError:
             pass
 
+        index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'GBECoreSlave')
+        GBECoreSlave = configuration['settings'][index_general]['data']['option'][index_option]
+        mcu['tool_specific']['iar']['GBECoreSlave'] = { 'state': [int(GBECoreSlave['state'])] }
+
+        if fileVersion == 2:
+            try:
+                index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NrRegs')
+                NrRegs = configuration['settings'][index_general]['data']['option'][index_option]
+                mcu['tool_specific']['iar']['NrRegs'] = { 'state': [int(NrRegs['state'])] }
+            except TypeError:
+                pass
+            try:
+                index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NEON')
+                NEON = configuration['settings'][index_general]['data']['option'][index_option]
+                mcu['tool_specific']['iar']['NEON'] = { 'state': [int(NEON['state'])] }
+            except TypeError:
+                pass
+            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'GFPUCoreSlave2')
+            GFPUCoreSlave2 = configuration['settings'][index_general]['data']['option'][index_option]
+            mcu['tool_specific']['iar']['GFPUCoreSlave2'] = { 'state': [int(GFPUCoreSlave2['state'])] }
+            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'CoreVariant')
+            CoreVariant = configuration['settings'][index_general]['data']['option'][index_option]
+            mcu['tool_specific']['iar']['CoreVariant'] = { 'state': [int(CoreVariant['state'])] }
+        else:
+            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'GFPUCoreSlave')
+            GFPUCoreSlave = configuration['settings'][index_general]['data']['option'][index_option]
+            mcu['tool_specific']['iar']['GFPUCoreSlave'] = { 'state': [int(GFPUCoreSlave['state'])] }
+            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'Variant')
+            Variant = configuration['settings'][index_general]['data']['option'][index_option]
+            mcu['tool_specific']['iar']['Variant'] = { 'state': [int(Variant['state'])] }
         return mcu
 
 class CoIDEdefinitions:


### PR DESCRIPTION
7.50 seems to be adding new schema, I noticed fileversion added there,
and suddenly is set to 2. Based on this, there are new MCU settings,
which we can process if they are there. FPU2, CoreVariant, etc..

This might require better versioning, once we understand IAR fileVersion.

I'll test this with older versions of IAR. I got 7.0 and 7.4 installed, will report if there's any regression.

With this new settings, STM nucleo F746 seems to have correct FPU settings without any errors.

IF any other targets needs FPU settings for iar, yaml should be updated !
