### PR TITLE
FPU target definition removal

### DIFF
--- a/project_generator_definitions/mcu/renesas/r7s721001.yaml
+++ b/project_generator_definitions/mcu/renesas/r7s721001.yaml
@@ -7,9 +7,6 @@ mcu:
     - renesas
 tool_specific:
     iar:
-        FPU:
-            state:
-            - 3
         GBECoreSlave:
             state:
             - 37

--- a/project_generator_definitions/mcu/st/stm32f746zg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746zg.yaml
@@ -10,21 +10,12 @@ tool_specific:
         CoreVariant:
             state:
             - 41
-        FPU2:
-            state:
-            - 6
         GFPUCoreSlave2:
             state:
             - 41
         GBECoreSlave:
             state:
             - 41
-        NEON:
-            state:
-            - 0
-        NrRegs:
-            state:
-            - 1
         OGChipSelectEditMenu:
             state:
             - STM32F746ZG ST STM32F746ZG

--- a/project_generator_definitions/tools.py
+++ b/project_generator_definitions/tools.py
@@ -142,18 +142,9 @@ class IARDefinitions:
         # we keep this as the internal version. FPU - version 1, FPU2 version 2. 
         # TODO:We shall look at IAR versioning to get this right
         fileVersion = 1
-        # It can be either FPU or FPU2
         try:
-            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'FPU2')
-            FPU2 = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['FPU2'] = { 'state': [int(FPU2['state'])] }
-            fileVersion = 2
-        except TypeError:
-            pass
-        try:
-            index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'FPU')
-            FPU = configuration['settings'][index_general]['data']['option'][index_option]
-            mcu['tool_specific']['iar']['FPU'] = { 'state': [int(FPU['state'])] }
+            if self._get_option(configuration['settings'][index_general]['data']['option'], 'FPU2'):
+                fileVersion = 2
         except TypeError:
             pass
 
@@ -162,18 +153,6 @@ class IARDefinitions:
         mcu['tool_specific']['iar']['GBECoreSlave'] = { 'state': [int(GBECoreSlave['state'])] }
 
         if fileVersion == 2:
-            try:
-                index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NrRegs')
-                NrRegs = configuration['settings'][index_general]['data']['option'][index_option]
-                mcu['tool_specific']['iar']['NrRegs'] = { 'state': [int(NrRegs['state'])] }
-            except TypeError:
-                pass
-            try:
-                index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'NEON')
-                NEON = configuration['settings'][index_general]['data']['option'][index_option]
-                mcu['tool_specific']['iar']['NEON'] = { 'state': [int(NEON['state'])] }
-            except TypeError:
-                pass
             index_option = self._get_option(configuration['settings'][index_general]['data']['option'], 'GFPUCoreSlave2')
             GFPUCoreSlave2 = configuration['settings'][index_general]['data']['option'][index_option]
             mcu['tool_specific']['iar']['GFPUCoreSlave2'] = { 'state': [int(GFPUCoreSlave2['state'])] }


### PR DESCRIPTION
Reverting the last changes for the current progendef version. FPU shall not be part of the target. This will come later to progen as separate feature addition.
