### PR TITLE
[Keil5] some STM32xxx definitions and Keil template extension

### DIFF
--- a/project_generator_definitions/mcu/arm-ssg/beetle.yaml
+++ b/project_generator_definitions/mcu/arm-ssg/beetle.yaml
@@ -20,5 +20,7 @@ tool_specific:
       - ARM.CMSIS.4.5.0
       SFDFile:
       - $$Device:ARMCM3$Device\ARM\SVD\ARMCM3.svd
+      RegisterFile:
+      - null
       Vendor:
       - ARM

--- a/project_generator_definitions/mcu/freescale/mk64fn1m0xxx12.yaml
+++ b/project_generator_definitions/mcu/freescale/mk64fn1m0xxx12.yaml
@@ -34,6 +34,8 @@ tool_specific:
                 - 7425
             SFDFile:
                 - $$Device:MK64FN1M0xxx12$SVD\MK64F12.svd
+            RegisterFile:
+            - $$Device:MK64FN1M0xxx12$Device\Include\MK64F12.h
             PackID:
                 - Keil.Kinetis_K60_DFP.1.4.0
     iar:

--- a/project_generator_definitions/mcu/freescale/mkl25z128xxx4.yaml
+++ b/project_generator_definitions/mcu/freescale/mkl25z128xxx4.yaml
@@ -34,6 +34,8 @@ tool_specific:
                 - 6533
             SFDFile:
                 - SFD\Freescale\Kinetis\MKL25Z4.sfr
+            RegisterFile:
+            - $$Device:MKL25Z128xxx4$Device\Include\MKL25Z4.h
             PackID:
                 - Keil.Kinetis_KLxx_DFP.1.6.0
     iar:

--- a/project_generator_definitions/mcu/nxp/lpc1768.yaml
+++ b/project_generator_definitions/mcu/nxp/lpc1768.yaml
@@ -34,6 +34,8 @@ tool_specific:
             - Keil.LPC1700_DFP.2.1.0
             SFDFile:
             - $$Device:LPC1768$SVD\LPC176x5x.svd
+            RegisterFile:
+            - $$Device:LPC1768$Device\Include\LPC17xx.h
             Vendor:
             - NXP
     iar:

--- a/project_generator_definitions/mcu/st/stm32f042x.yaml
+++ b/project_generator_definitions/mcu/st/stm32f042x.yaml
@@ -36,10 +36,6 @@ tool_specific:
             - $$Device:STM32F042K6$SVD\STM32F042x.svd
             RegisterFile:
             - $$Device:STM32F042K6$Device\Include\stm32f0xx.h
-            uLib:
-            - 1
-            OptFeed:
-            - 1
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f042x.yaml
+++ b/project_generator_definitions/mcu/st/stm32f042x.yaml
@@ -23,7 +23,7 @@ tool_specific:
     uvision5:
         TargetOption:
             Cpu:
-            - IROM(0x08000000,0x8000) IRAM(0x20000000,0x1800) CPUTYPE("Cortex-M0") CLOCK(12000000) ELITTLE
+            - IROM(0x08000000,0x8000) IRAM(0x20000000,0x1800) CPUTYPE("Cortex-M0") CLOCK(8000000) ELITTLE
             Device:
             - STM32F042K6
             DeviceId:

--- a/project_generator_definitions/mcu/st/stm32f042x.yaml
+++ b/project_generator_definitions/mcu/st/stm32f042x.yaml
@@ -20,6 +20,28 @@ tool_specific:
             - $$Device:STM32F042K6$SVD\STM32F042x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x8000) IRAM(0x20000000,0x1800) CPUTYPE("Cortex-M0") CLOCK(12000000) ELITTLE
+            Device:
+            - STM32F042K6
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F0xx_32 -FS08000000 -FL08000 -FP0($$Device:STM32F042K6$Flash\STM32F0xx_32.FLM))
+            PackID:
+            - Keil.STM32F0xx_DFP.1.4.0
+            SFDFile:
+            - $$Device:STM32F042K6$SVD\STM32F042x.svd
+            RegisterFile:
+            - $$Device:STM32F042K6$Device\Include\stm32f0xx.h
+            uLib:
+            - 1
+            OptFeed:
+            - 1
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f303x8.yaml
+++ b/project_generator_definitions/mcu/st/stm32f303x8.yaml
@@ -20,6 +20,28 @@ tool_specific:
             - $$Device:STM32F303K8$SVD\STM32F303x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x00010000) IRAM(0x20000000,0x00003000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE
+            Device:
+            - STM32F303K8
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F3xx_256 -FS08000000 -FL010000 -FP0($$Device:STM32F303K8$Flash\STM32F3xx_256.FLM))
+            PackID:
+            - Keil.STM32F3xx_DFP.1.3.0
+            SFDFile:
+            - $$Device:STM32F303K8$SVD\STM32F303x.svd
+            RegisterFile:
+            - $$Device:STM32F303K8$Device\Include\stm32f3xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f303x8.yaml
+++ b/project_generator_definitions/mcu/st/stm32f303x8.yaml
@@ -36,10 +36,6 @@ tool_specific:
             - $$Device:STM32F303K8$SVD\STM32F303x.svd
             RegisterFile:
             - $$Device:STM32F303K8$Device\Include\stm32f3xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f303x8.yaml
+++ b/project_generator_definitions/mcu/st/stm32f303x8.yaml
@@ -9,7 +9,7 @@ tool_specific:
     uvision:
         TargetOption:
             Cpu:
-            - IROM(0x08000000,0x00010000) IRAM(0x20000000,0x00003000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE
+            - IROM(0x08000000,0x00010000) IRAM(0x20000000,0x00003000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
             Device:
             - STM32F303K8
             DeviceId:

--- a/project_generator_definitions/mcu/st/stm32f303xe.yaml
+++ b/project_generator_definitions/mcu/st/stm32f303xe.yaml
@@ -27,3 +27,25 @@ tool_specific:
             - $$Device:STM32F302RC$SVD\STM32F30x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x00080000) IRAM(0x20000000,0x00010000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F303RE
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F3xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F303RE$Flash\STM32F3xx_512.FLM))
+            PackID:
+            - Keil.STM32F3xx_DFP.1.3.0
+            SFDFile:
+            - $$Device:STM32F303RE$SVD\STM32F303xE.svd
+            RegisterFile:
+            - $$Device:STM32F303RE$Device\Include\stm32f3xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f303xe.yaml
+++ b/project_generator_definitions/mcu/st/stm32f303xe.yaml
@@ -43,9 +43,5 @@ tool_specific:
             - $$Device:STM32F303RE$SVD\STM32F303xE.svd
             RegisterFile:
             - $$Device:STM32F303RE$Device\Include\stm32f3xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f401xe.yaml
+++ b/project_generator_definitions/mcu/st/stm32f401xe.yaml
@@ -20,6 +20,28 @@ tool_specific:
                 - 7383
             SFDFile:
                 - $$Device:STM32F401RC$SVD\STM32F40x.svd
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x80000) IRAM(0x20000000,0x18000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F401RETx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F401RETx$CMSIS\Flash\STM32F4xx_512.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F401RETx$CMSIS\SVD\STM32F401xE.svd
+            RegisterFile:
+            - $$Device:STM32F401RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f401xe.yaml
+++ b/project_generator_definitions/mcu/st/stm32f401xe.yaml
@@ -36,10 +36,6 @@ tool_specific:
             - $$Device:STM32F401RETx$CMSIS\SVD\STM32F401xE.svd
             RegisterFile:
             - $$Device:STM32F401RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f407vg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f407vg.yaml
@@ -34,5 +34,11 @@ tool_specific:
             - Keil.STM32F4xx_DFP.2.8.0
             SFDFile:
             - $$Device:STM32F407VGTx$CMSIS\SVD\STM32F40x.svd
+            RegisterFile:
+            - $$Device:STM32F407VGTx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f407vg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f407vg.yaml
@@ -20,3 +20,19 @@ tool_specific:
             - SFD\ST\STM32F4xx\STM32F40x.sfr
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x100000) IRAM(0x20000000,0x20000) IRAM2(0x10000000,0x10000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F407VGTx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32F407VGTx$CMSIS\Flash\STM32F4xx_1024.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F407VGTx$CMSIS\SVD\STM32F40x.svd
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f407vg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f407vg.yaml
@@ -36,9 +36,5 @@ tool_specific:
             - $$Device:STM32F407VGTx$CMSIS\SVD\STM32F40x.svd
             RegisterFile:
             - $$Device:STM32F407VGTx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f410rb.yaml
+++ b/project_generator_definitions/mcu/st/stm32f410rb.yaml
@@ -36,10 +36,6 @@ tool_specific:
             - $$Device:STM32F410RBTx$CMSIS\SVD\STM32F410xx.svd
             RegisterFile:
             - $$Device:STM32F410RBTx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f410rb.yaml
+++ b/project_generator_definitions/mcu/st/stm32f410rb.yaml
@@ -20,6 +20,28 @@ tool_specific:
             - $$Device:STM32F410RBTx$CMSIS\SVD\STM32F410xx.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x20000) IRAM(0x20000000,0x8000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F410RBTx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_128 -FS08000000 -FL020000 -FP0($$Device:STM32F410RBTx$CMSIS\Flash\STM32F4xx_128.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F410RBTx$CMSIS\SVD\STM32F410xx.svd
+            RegisterFile:
+            - $$Device:STM32F410RBTx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f411re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f411re.yaml
@@ -27,3 +27,25 @@ tool_specific:
             - $$Device:STM32F401RC$SVD\STM32F40x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x80000) IRAM(0x20000000,0x20000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F411RETx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F401RETx$CMSIS\Flash\STM32F4xx_512.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F411RETx$CMSIS\SVD\STM32F411xx.svd
+            RegisterFile:
+            - $$Device:STM32F411RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f411re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f411re.yaml
@@ -43,9 +43,5 @@ tool_specific:
             - $$Device:STM32F411RETx$CMSIS\SVD\STM32F411xx.svd
             RegisterFile:
             - $$Device:STM32F411RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f411re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f411re.yaml
@@ -36,7 +36,7 @@ tool_specific:
             DeviceId:
             - null
             FlashDriverDll:
-            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F401RETx$CMSIS\Flash\STM32F4xx_512.FLM))
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F411RETx$CMSIS\Flash\STM32F4xx_512.FLM))
             PackID:
             - Keil.STM32F4xx_DFP.2.8.0
             SFDFile:

--- a/project_generator_definitions/mcu/st/stm32f429zi.yaml
+++ b/project_generator_definitions/mcu/st/stm32f429zi.yaml
@@ -36,6 +36,10 @@ tool_specific:
             - $$Device:STM32F429ZITx$CMSIS\SVD\STM32F429x.svd
             RegisterFile:
             - $$Device:STM32F429ZITx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f429zi.yaml
+++ b/project_generator_definitions/mcu/st/stm32f429zi.yaml
@@ -36,10 +36,6 @@ tool_specific:
             - $$Device:STM32F429ZITx$CMSIS\SVD\STM32F429x.svd
             RegisterFile:
             - $$Device:STM32F429ZITx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics
     iar:

--- a/project_generator_definitions/mcu/st/stm32f429zi.yaml
+++ b/project_generator_definitions/mcu/st/stm32f429zi.yaml
@@ -20,6 +20,24 @@ tool_specific:
             - SFD\ST\STM32F4xx\STM32F42x.sfr
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x200000) IRAM(0x20000000,0x30000) IRAM2(0x10000000,0x10000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F429ZITx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_2048 -FS08000000 -FL0200000 -FP0($$Device:STM32F429ZITx$CMSIS\Flash\STM32F4xx_2048.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F429ZITx$CMSIS\SVD\STM32F429x.svd
+            RegisterFile:
+            - $$Device:STM32F429ZITx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f446re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f446re.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - $$Device:STM32F446RETx$CMSIS\SVD\STM32F446x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x80000) IRAM(0x20000000,0x20000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            AdsCpuType:
+            - "Cortex-M4"
+            Device:
+            - STM32F446RETx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F446RETx$CMSIS\Flash\STM32F4xx_512.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F446RETx$CMSIS\SVD\STM32F446x.svd
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f446re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f446re.yaml
@@ -31,8 +31,6 @@ tool_specific:
         TargetOption:
             Cpu:
             - IROM(0x08000000,0x80000) IRAM(0x20000000,0x20000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
-            AdsCpuType:
-            - "Cortex-M4"
             Device:
             - STM32F446RETx
             DeviceId:
@@ -43,5 +41,11 @@ tool_specific:
             - Keil.STM32F4xx_DFP.2.8.0
             SFDFile:
             - $$Device:STM32F446RETx$CMSIS\SVD\STM32F446x.svd
+            RegisterFile:
+            - $$Device:STM32F446RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f446re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f446re.yaml
@@ -43,9 +43,5 @@ tool_specific:
             - $$Device:STM32F446RETx$CMSIS\SVD\STM32F446x.svd
             RegisterFile:
             - $$Device:STM32F446RETx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f746ng.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746ng.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - $$Device:STM32F756IG$CMSIS\SVD\STM32F7x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x100000) IROM2(0x00200000,0x100000) IRAM(0x20010000,0x40000) IRAM2(0x20000000,0x10000) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE
+            Device:
+            - STM32F746NGHx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20010000 -FC1000 -FN1 -FF0STM32F7x_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32F746NGHx$CMSIS\Flash\STM32F7x_1024.FLM))
+            PackID:
+            - Keil.STM32F7xx_DFP.2.5.0
+            SFDFile:
+            - $$Device:STM32F746NGHx$CMSIS\SVD\STM32F7x.svd
+            RegisterFile:
+            - $$Device:STM32F746NGHx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f746ng.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746ng.yaml
@@ -43,9 +43,5 @@ tool_specific:
             - $$Device:STM32F746NGHx$CMSIS\SVD\STM32F7x.svd
             RegisterFile:
             - $$Device:STM32F746NGHx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f746ng.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746ng.yaml
@@ -30,7 +30,7 @@ tool_specific:
     uvision5:
         TargetOption:
             Cpu:
-            - IROM(0x08000000,0x100000) IROM2(0x00200000,0x100000) IRAM(0x20010000,0x40000) IRAM2(0x20000000,0x10000) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE
+            - IROM(0x08000000,0x100000) IROM2(0x00200000,0x100000) IRAM(0x20010000,0x40000) IRAM2(0x20000000,0x10000) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(8000000) ELITTLE
             Device:
             - STM32F746NGHx
             DeviceId:
@@ -43,5 +43,9 @@ tool_specific:
             - $$Device:STM32F746NGHx$CMSIS\SVD\STM32F7x.svd
             RegisterFile:
             - $$Device:STM32F746NGHx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f746zg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746zg.yaml
@@ -38,9 +38,5 @@ tool_specific:
             - $$Device:STM32F746ZGTx$CMSIS\SVD\STM32F7x.svd
             RegisterFile:
             - $$Device:STM32F746ZGTx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
-            uLib:
-            - 0
-            OptFeed:
-            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32f746zg.yaml
+++ b/project_generator_definitions/mcu/st/stm32f746zg.yaml
@@ -25,16 +25,22 @@ tool_specific:
     uvision5:
         TargetOption:
             Cpu:
-            - IROM(0x08000000-0x080FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE
+            - IROM(0x08000000,0x100000) IROM2(0x00200000,0x100000) IRAM(0x20010000,0x40000) IRAM2(0x20000000,0x10000) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(8000000) ELITTLE
             Device:
-            - STM32F746ZG
+            - STM32F746ZGTx
             DeviceId:
             - null
             FlashDriverDll:
-            - null
+            - UL2CM3(-S0 -C0 -P0 -FD20010000 -FC1000 -FN1 -FF0STM32F7x_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32F746ZGTx$CMSIS\Flash\STM32F7x_1024.FLM))
             PackID:
-            - Keil.STM32F7xx_DFP.1.0.0
+            - Keil.STM32F7xx_DFP.2.3.0
             SFDFile:
-            - $$Device:STM32F756IG$CMSIS\SVD\STM32F7x.svd
+            - $$Device:STM32F746ZGTx$CMSIS\SVD\STM32F7x.svd
+            RegisterFile:
+            - $$Device:STM32F746ZGTx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
+            uLib:
+            - 0
+            OptFeed:
+            - 0
             Vendor:
             - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l031x6.yaml
+++ b/project_generator_definitions/mcu/st/stm32l031x6.yaml
@@ -9,17 +9,19 @@ tool_specific:
     uvision5:
         TargetOption:
             Cpu:
-            - IRAM(0x20000000-0x20001FFF) IROM(0x8000000-0x8007FFF) CLOCK(8000000) CPUTYPE("Cortex-M0+")
+            - IROM(0x08000000,0x00008000) IRAM(0x20000000,0x00002000) CPUTYPE("Cortex-M0+") CLOCK(8000000) ELITTLE
             Device:
             - STM32L031K6
             DeviceId:
             - null
             FlashDriverDll:
-            - null
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L0xx_32 -FS08000000 -FL08000 -FP0($$Device:STM32L031K6Tx$Flash\STM32L0xx_32.FLM))
             PackID:
             - Keil.STM32L0xx_DFP.1.5.0
             SFDFile:
             - $$Device:STM32L031K6$SVD\STM32L051x.svd
+            RegisterFile:
+            - $$Device:STM32L031K6Tx$Device\Include\stm32l0xx.h
             Vendor:
             - STMicroelectronics
     iar:


### PR DESCRIPTION
- adding uvision5 mcu config options for several STM32xxx
- extending the options by RegisterfileOption - this option was missing before
- adding RegisterfileOption to all mcus with already existing Keil5 config
- adding RegisterfileOption to beetle.yaml with null value - I didn't test this config
- all other configs are tested with mbed BLINKY export to Keil5

Please see discussion at PR #70

A corresponding PR (project-generator/project_generator#381) is submitted in project_generator repository.
