### PR TITLE
uvision - register file addition

### DIFF
--- a/project_generator_definitions/tools.py
+++ b/project_generator_definitions/tools.py
@@ -47,6 +47,7 @@ class UvisionDefinition:
                         'Cpu' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['Cpu']],
                         'FlashDriverDll' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['FlashDriverDll']],
                         'SFDFile' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['SFDFile']],
+                        'RegisterFile': [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['RegisterFile']],
                     }
                 }
             }
@@ -79,6 +80,7 @@ class UvisionDefinition5:
                         'FlashDriverDll' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['FlashDriverDll']],
                         'SFDFile' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['SFDFile']],
                         'PackID' : [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['PackID']],
+                        'RegisterFile': [uvproj_dic['Project']['Targets']['Target']['TargetOption']['TargetCommonOption']['RegisterFile']],
                     }
                 }
             }


### PR DESCRIPTION
```
RegisterFile:
  - $$Device:MK64FN1M0xxx12$Device\Include\MK64F12.h
```

Should fix #77

I added it to both uvision4 and uvision5. We need to consolide those options as they have some common
