### PR TITLE
Add micro:bit support for project generator, based on nRF51

### DIFF
--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -159,6 +159,9 @@ PROGENDEF_TARGETS = {
     'mbed-lpc11u24': {
         'mcu':'mcu/nxp/lpc11u24_201',
     },
+    'bbc-microbit': {
+        'mcu':'mcu/nordic/nrf51822',
+    },
     'mkit': {
         'mcu':'mcu/nordic/nrf51822',
     },


### PR DESCRIPTION
The bbc-microbit is based on the nRF51822 and as such can be easily
added to project generator export.
