### PR TITLE
[MCU definitions] adding several Keil5 definitions, adding 2 new STM mcus

### DIFF
--- a/project_generator_definitions/mcu/st/stm32f469nihx.yaml
+++ b/project_generator_definitions/mcu/st/stm32f469nihx.yaml
@@ -20,6 +20,24 @@ tool_specific:
             - null
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x50000) IROM(0x08000000,0x200000) CPUTYPE("Cortex-M4") FPU2 CLOCK(12000000) ELITTLE
+            Device:
+            - STM32F469NIHx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN2 -FF0STM32F4xx_2048 -FS08000000 -FL0200000 -FF1STM32F469_Quad_SPI -FS190000000 -FL12000000 -FP0($$Device:STM32F469NIHx$CMSIS\Flash\STM32F4xx_2048.FLM) -FP1($$Device:STM32F469NIHx$CMSIS\Flash\STM32F469_Quad_SPI.FLM))
+            PackID:
+            - Keil.STM32F4xx_DFP.2.8.0
+            SFDFile:
+            - $$Device:STM32F469NIHx$CMSIS\SVD\STM32F46_79x.svd
+            RegisterFile:
+            - $$Device:STM32F469NIHx$Drivers\CMSIS\Device\ST\STM32F4xx\Include\stm32f4xx.h
+            Vendor:
+            - STMicroelectronics
     iar:
         OGChipSelectEditMenu:
           state:

--- a/project_generator_definitions/mcu/st/stm32f767zi.yaml
+++ b/project_generator_definitions/mcu/st/stm32f767zi.yaml
@@ -1,0 +1,26 @@
+mcu:
+    vendor:
+        - st
+    name:
+        - stm32f767zi
+    core:
+        - cortex-m7f
+tool_specific:
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IROM(0x08000000,0x200000) IROM2(0x00200000,0x200000) IRAM(0x20020000,0x60000) IRAM2(0x20000000,0x20000) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F767ZITx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20020000 -FC1000 -FN2 -FF0STM32F7x_2048 -FS08000000 -FL0200000 -FF1STM32F7xTCM_2048 -FS1200000 -FL1200000 -FP0($$Device:STM32F767ZITx$CMSIS\Flash\STM32F7x_2048.FLM) -FP1($$Device:STM32F767ZITx$CMSIS\Flash\STM32F7xTCM_2048.FLM))
+            PackID:
+            - Keil.STM32F7xx_DFP.2.6.0
+            SFDFile:
+            - $$Device:STM32F767ZITx$CMSIS\SVD\STM32F7x7.svd
+            RegisterFile:
+            - $$Device:STM32F767ZITx$Drivers\CMSIS\Device\ST\STM32F7xx\Include\stm32f7xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l053x8.yaml
+++ b/project_generator_definitions/mcu/st/stm32l053x8.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - null
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x00002000) IROM(0x08000000,0x00010000) CPUTYPE("Cortex-M0+") CLOCK(8000000) ELITTLE
+            Device:
+            - STM32L053R8Hx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L0xx_64 -FS08000000 -FL010000 -FP0($$Device:STM32L053R8Hx$Flash\STM32L0xx_64.FLM))
+            PackID:
+            - Keil.STM32L0xx_DFP.1.5.0
+            SFDFile:
+            - $$Device:STM32L053R8Hx$SVD\STM32L053x.svd
+            RegisterFile:
+            - $$Device:STM32L053R8Hx$Device\Include\stm32l0xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l073xz.yaml
+++ b/project_generator_definitions/mcu/st/stm32l073xz.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - null
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x00005000) IROM(0x08000000,0x00030000) CPUTYPE("Cortex-M0+") CLOCK(8000000) ELITTLE
+            Device:
+            - STM32L073RZHx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L0xx_192 -FS08000000 -FL030000 -FP0($$Device:STM32L073RZHx$Flash\STM32L0xx_192.FLM))
+            PackID:
+            - Keil.STM32L0xx_DFP.1.5.0
+            SFDFile:
+            - $$Device:STM32L073RZHx$SVD\STM32L07x.svd
+            RegisterFile:
+            - $$Device:STM32L073RZHx$Device\Include\stm32l0xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l152xe.yaml
+++ b/project_generator_definitions/mcu/st/stm32l152xe.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - $$Device:STM32L152RD$SVD\STM32L15x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x14000) IROM(0x08000000,0x80000) CPUTYPE("Cortex-M3") CLOCK(8000000) ELITTLE
+            Device:
+            - STM32L152RE
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L1xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32L152RE$Flash\STM32L1xx_512.FLM))
+            PackID:
+            - Keil.STM32L1xx_DFP.1.0.2
+            SFDFile:
+            - $$Device:STM32L152RE$SVD\STM32L1xx.svd
+            RegisterFile:
+            - $$Device:STM32L152RE$Device\Include\STM32L1xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l476rg.yaml
+++ b/project_generator_definitions/mcu/st/stm32l476rg.yaml
@@ -1,0 +1,26 @@
+mcu:
+    vendor:
+        - st
+    name:
+        - stm32l476rg
+    core:
+        - cortex-m4
+tool_specific:
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x00018000) IRAM2(0x10000000,0x00008000) IROM(0x08000000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32L476RGTx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L4xx_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32L476RGTx$Flash\STM32L4xx_1024.FLM))
+            PackID:
+            - Keil.STM32L4xx_DFP.1.2.0
+            SFDFile:
+            - $$Device:STM32L476RGTx$SVD\STM32L4x6.svd
+            RegisterFile:
+            - $$Device:STM32L476RGTx$Device\Include\stm32l4xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/mcu/st/stm32l476vg.yaml
+++ b/project_generator_definitions/mcu/st/stm32l476vg.yaml
@@ -27,3 +27,21 @@ tool_specific:
             - $$Device:STM32L476RG$SVD\STM32L4x.svd
             Vendor:
             - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x00018000) IRAM2(0x10000000,0x00008000) IROM(0x08000000,0x00100000) CPUTYPE("Cortex-M4") FPU2 CLOCK(8000000) ELITTLE
+            Device:
+            - STM32L476VGTx
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32L4xx_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32L476VGTx$Flash\STM32L4xx_1024.FLM))
+            PackID:
+            - Keil.STM32L4xx_DFP.1.2.0
+            SFDFile:
+            - $$Device:STM32L476VGTx$SVD\STM32L4x6.svd
+            RegisterFile:
+            - $$Device:STM32L476VGTx$Device\Include\stm32l4xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -315,7 +315,7 @@ PROGENDEF_TARGETS = {
         }
     },
     'nucleo-l476rg': {
-        'mcu':'mcu/st/stm32l476vg',
+        'mcu':'mcu/st/stm32l476rg',
         'debugger': {
             'name': 'st-link',
             'interface': 'swd',
@@ -337,6 +337,13 @@ PROGENDEF_TARGETS = {
     },
     'nucleo-f746zg': {
         'mcu':'mcu/st/stm32f746zg',
+        'debugger': {
+            'name': 'st-link',
+            'interface': 'swd',
+        }
+    },
+    'nucleo-f767zi': {
+        'mcu':'mcu/st/stm32f767zi',
         'debugger': {
             'name': 'st-link',
             'interface': 'swd',


### PR DESCRIPTION
- adding Keil5 option for STM32L476VG, STM32L152XE, STM32L073XZ, STM32L053x8 and STM32F469NI for several NUCLEO and DISCOVERY boards
- adding new mcus: STM32L476RG and STM32F676ZI for two NUCLEO boards
- correcting one typo STM32L476VG/RG and adding a new mcu in targets.py
