### PR TITLE
stm32f411re - uvision flash algo fix

### DIFF
--- a/project_generator_definitions/mcu/st/stm32f411re.yaml
+++ b/project_generator_definitions/mcu/st/stm32f411re.yaml
@@ -22,7 +22,7 @@ tool_specific:
             DeviceId:
             - 7383
             FlashDriverDll:
-            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000 -FP0($$Device:STM32F411RETx$CMSIS\Flash\STM32F4xx_512.FLM))
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_512 -FS08000000 -FL080000)
             SFDFile:
             - $$Device:STM32F411RETx$CMSIS\SVD\STM32F411xx.svd
             Vendor:


### PR DESCRIPTION
This is still under review. I was not able to make 512k for nucleo f411 without this change.

What I did, set to 512k, save , parse and get this data

@bcostm @adustm @ohagendorf 
