### PR TITLE
[ARDUCLEO_F051K8] add to target.py (new stm32f051k8 mcu)

### DIFF
--- a/project_generator_definitions/mcu/st/stm32f051x.yaml
+++ b/project_generator_definitions/mcu/st/stm32f051x.yaml
@@ -1,0 +1,47 @@
+mcu:
+    vendor:
+        - st
+    name:
+        - stm32f051x
+    core:
+        - cortex-m0
+tool_specific:
+    iar:
+        OGChipSelectEditMenu:
+          state:
+          - STM32F051x8 ST STM32F051x8
+        OGCoreOrChip:
+          state:
+          - 1
+    uvision:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000-0x20001FFF) IROM(0x8000000-0x800FFFF) CLOCK(8000000) CPUTYPE("Cortex-M0")
+            Device:
+            - STM32F051K8
+            DeviceId:
+            - 6560
+            FlashDriverDll:
+            - UL2CM3(-O207 -S0 -C0 -FO7 -FD20000000 -FC800 -FN1 -FF0STM32F0xx_64 -FS08000000 -FL08000)
+            SFDFile:
+            - SFD\ST\STM32F0xx\STM32F0xx.sfr
+            Vendor:
+            - STMicroelectronics
+    uvision5:
+        TargetOption:
+            Cpu:
+            - IRAM(0x20000000,0x2000) IROM(0x08000000,0x10000) CPUTYPE("Cortex-M0") CLOCK(8000000) ELITTLE
+            Device:
+            - STM32F051K8
+            DeviceId:
+            - null
+            FlashDriverDll:
+            - UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F0xx_64 -FS08000000 -FL08000 -FP0($$Device:STM32F051K8$Flash\STM32F0xx_64.FLM))
+            PackID:
+            - Keil.STM32F0xx_DFP.1.5.0
+            SFDFile:
+            - $$Device:STM32F051K8$SVD\STM32F0x1.svd
+            RegisterFile:
+            - $$Device:STM32F051K8$Device\Include\stm32f0xx.h
+            Vendor:
+            - STMicroelectronics

--- a/project_generator_definitions/target/targets.py
+++ b/project_generator_definitions/target/targets.py
@@ -423,6 +423,13 @@ PROGENDEF_TARGETS = {
             'interface': 'swd',
         }
     },
+    'arducleo-f051k8': {
+        'mcu':'mcu/st/stm32f051x',
+        'debugger': {
+            'name': 'cmsis-dap',
+            'interface': 'swd',
+        }
+    },
     'ublox-c027': {
         'mcu':'mcu/nxp/lpc1768',
     },


### PR DESCRIPTION
stm32f051 is more powerful than stm32f031k6. wish this new mcu can be supported.
