### PR TITLE
github: Remove python 3.6, add 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
         - "3.10"
+        - 3.11
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
master is failing as CI has not run for some time and 3.6 is out already.